### PR TITLE
[APIS-801] change the type of ext_type to 'unsigned char' of the T_CCII_COLUMN_INFO

### DIFF
--- a/col_info.h
+++ b/col_info.h
@@ -31,7 +31,7 @@ typedef struct
 
 typedef struct
   {
-    T_CCI_U_EXT_TYPE ext_type;
+    unsigned char ext_type;
     char is_non_null;
     short scale;
     int precision;


### PR DESCRIPTION
The type of the member ext_type of T_CCI_COLUMN_INFO was T_CCI_U_EXT_TYPE.
But the type is not defined earlier versions. It should be changed to 'unsigned char' for compatibility.